### PR TITLE
Vendor in libyaml to prepare for RHEL-derivatives

### DIFF
--- a/recipes/libyaml.rb
+++ b/recipes/libyaml.rb
@@ -1,0 +1,27 @@
+class Ruby193 < FPM::Cookery::Recipe
+  description 'LibYAML is a YAML 1.1 parser and emitter written in C'
+
+  name 'libyaml'
+  version '0.1.4'
+  revision 1
+  homepage 'http://pyyaml.org/wiki/LibYAML'
+  source 'http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz'
+  sha256 '7bf81554ae5ab2d9b6977da398ea789722e0db75b86bffdaeb4e66d961de6a37'
+
+  maintainer '<beddari@deploy.no>'
+  vendor     'fpm'
+  license    'MIT license'
+
+  section 'libraries'
+
+  build_depends 'build-essential'
+
+  def build
+    configure :prefix => "/opt/puppet-omnibus/embedded"
+    make
+  end
+
+  def install
+    make :install
+  end
+end

--- a/recipes/puppet-omnibus.rb
+++ b/recipes/puppet-omnibus.rb
@@ -13,8 +13,9 @@ class PuppetOmnibus < FPM::Cookery::Recipe
   source '', :with => :noop
 
   omnibus_package true
-  omnibus_recipes "ruby", "facter-gem", "json_pure-gem", "hiera-gem", "ruby-augeas-gem", \
-                  "ruby-shadow-gem", "fog-gem", "aws-sdk-gem", "puppet-gem", "init-script"
+  omnibus_recipes "libyaml", "ruby", "facter-gem", "json_pure-gem", "hiera-gem",
+                  "ruby-augeas-gem", "ruby-shadow-gem", "fog-gem", "aws-sdk-gem",
+                  "puppet-gem", "init-script"
   omnibus_dir     "/opt/puppet-omnibus"
   omnibus_additional_paths "/etc/init.d/puppet"
 

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -15,14 +15,15 @@ class Ruby193 < FPM::Cookery::Recipe
   section 'interpreters'
 
   build_depends 'autoconf', 'libreadline6-dev', 'bison', 'zlib1g-dev',
-                'libssl-dev', 'libyaml-dev', 'libncurses5-dev', 'build-essential',
+                'libssl-dev', 'libncurses5-dev', 'build-essential',
                 'libffi-dev', 'libgdbm-dev'
 
   depends 'libffi6', 'libncurses5', 'libreadline6', 'libssl1.0.0', 'libtinfo5',
-          'libyaml-0-2', 'zlib1g', 'libgdbm3'
+          'zlib1g', 'libgdbm3'
 
   def build
-    configure :prefix => "/opt/puppet-omnibus/embedded", 'disable-install-doc' => true
+    configure :prefix => "/opt/puppet-omnibus/embedded", 'disable-install-doc' => true,
+              'with-opt-dir' => '/opt/puppet-omnibus/embedded"
     make
   end
 


### PR DESCRIPTION
If we are going to support building packages for RHEL-variants it would be wise to also build in libyaml so that we do not require EPEL for dependencies.

This adds a recipe for libyaml, adds it to compile before Ruby in puppet-omnibus.rb and adds the required path to the Ruby recipe.
