### PR TITLE
fixed mismatched quotes causing exception building under ubuntu / deb

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -23,7 +23,7 @@ class Ruby193 < FPM::Cookery::Recipe
 
   def build
     configure :prefix => "/opt/puppet-omnibus/embedded", 'disable-install-doc' => true,
-              'with-opt-dir' => '/opt/puppet-omnibus/embedded"
+              'with-opt-dir' => "/opt/puppet-omnibus/embedded"
     make
   end
 


### PR DESCRIPTION
syntax error, unexpected $end, expecting keyword_end

tested fixes issue on Ubuntu precise
