### PR TITLE
Fix up pre-uninstall script so it uses the correct scriptlet argument

### DIFF
--- a/puppet.rb
+++ b/puppet.rb
@@ -118,7 +118,7 @@ set -e
 BIN_PATH="#{destdir}/bin"
 BINS="puppet facter hiera"
 
-if [ "$1" != "upgrade" ]; then
+if [ "$1" -eq 0 ]; then
   for BIN in $BINS; do
     update-alternatives --remove $BIN $BIN_PATH/$BIN
   done


### PR DESCRIPTION
The pre-uninstall scriptlet blocks the removal of a package. It is trying to compare the scriptlet argument to a string with the value of "upgrade" but this doesn't work with RPM version 4.8.0 and it doesn't seem to be documented.

Modified the scriptlet to compare integer values as described in the below sources:
https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch09s04s05.html
http://www.rpm.org/max-rpm-snapshot/s1-rpm-inside-scripts.html
